### PR TITLE
[Microservices] Node manager - (1) added a API (2) Removed memory repository

### DIFF
--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/controller/NodeController.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/controller/NodeController.java
@@ -63,12 +63,10 @@ public class NodeController {
             RestPreconditionsUtil.verifyParameterNotNullorEmpty(nodeid);
             hostInfo = service.getNodeInfoById(nodeid);
         } catch (ParameterNullOrEmptyException e) {
-            //TODO: REST error code
             throw new Exception(e);
         }
 
         if (hostInfo == null) {
-            //TODO: REST error code
             return new NodeInfoJson();
         }
         return new NodeInfoJson(hostInfo);
@@ -82,11 +80,9 @@ public class NodeController {
         try {
             nodes = service.getAllNodes();
         } catch (ParameterNullOrEmptyException e) {
-            //TODO: REST error code
             throw new Exception(e);
         }
         if (nodes == null) {
-            //TODO: REST error code
             return new ArrayList();
         }
         return nodes;

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/dao/NodeRepository.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/dao/NodeRepository.java
@@ -74,6 +74,7 @@ public class NodeRepository implements ICacheRepository<NodeInfo> {
 
     /**
      * add a new node info to node repository
+     *
      * @param nodeInfo new node information
      * @return void
      * @throws Exception Db or cache operation exception
@@ -90,6 +91,7 @@ public class NodeRepository implements ICacheRepository<NodeInfo> {
 
     /**
      * add a new node info to node repository
+     *
      * @param nodes new nodes list
      * @return void
      * @throws Exception Db or cache operation exception
@@ -97,7 +99,7 @@ public class NodeRepository implements ICacheRepository<NodeInfo> {
     public void addItemBulkTransaction(List<NodeInfo> nodes) throws Exception {
         logger.info("Add nodes: " + nodes.size());
         try (Transaction tx = cache.getTransaction().start()) {
-            for(NodeInfo node: nodes){
+            for (NodeInfo node : nodes) {
                 cache.put(node.getId(), node);
             }
             tx.commit();

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/DataCenterConfigLoader.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/DataCenterConfigLoader.java
@@ -16,7 +16,6 @@ Licensed under the Apache License, Version 2.0 (the "License");
 
 package com.futurewei.alcor.nodemanager.service.implement;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.futurewei.alcor.nodemanager.entity.NodeInfo;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -24,10 +23,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ResourceLoader;
-import org.springframework.stereotype.Component;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;

--- a/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeServiceImpl.java
+++ b/services/node_manager/src/main/java/com/futurewei/alcor/nodemanager/service/implement/NodeServiceImpl.java
@@ -22,11 +22,9 @@ import com.futurewei.alcor.nodemanager.utils.NodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
 
 @Service
@@ -41,7 +39,7 @@ public class NodeServiceImpl implements NodeService {
         int nReturn = 0;
         DataCenterConfigLoader dataCenterConfigLoader = new DataCenterConfigLoader();
         List<NodeInfo> nodeList = dataCenterConfigLoader.loadAndGetHostNodeList(path);
-        if(nodeList != null){
+        if (nodeList != null) {
             nodeRepository.addItemBulkTransaction(nodeList);
             nReturn = nodeList.size();
         }

--- a/services/node_manager/src/main/resources/application.properties
+++ b/services/node_manager/src/main/resources/application.properties
@@ -5,4 +5,4 @@ ignite.key-store-path=keystore.jks
 ignite.key-store-password=123456
 ignite.trust-store-path=truststore.jks
 ignite.trust-store-password=123456
-#alcor.machine.config=D:\\dev\\alcor\\config\\machine.json
+


### PR DESCRIPTION
Two changes:
(1) Added a new API (getNodeInfoFromFile) which reads machine.json.
     test: curl http://localhost:8080/nodes/path/D:/dev/alcor/config/machine.json
(2) Deleted memory repository.
